### PR TITLE
Bugfix: Last Rank Date

### DIFF
--- a/player_rank_script.py
+++ b/player_rank_script.py
@@ -144,7 +144,8 @@ class ClanRankScriptHandler(PromptRunner):
             player_info = PlayerRankHandler(player_hiscore).get_max_levels_info()
             debug_print(str(player_info))
             new_rank = player_info["rank"]
-            status = self.clan_db.update_player(player, new_rank=new_rank, active_cnt=False)
+            if new_rank != player_rank:
+                status = self.clan_db.update_player(player, new_rank=new_rank, active_cnt=False)
         
         if status.res and new_rank > player_rank:
             print(f"   Player {player} is promoted from rank {player_rank} to {new_rank}")


### PR DESCRIPTION
Every clan update, clan members within achievement rank and beyond are getting their ranks updated every ranking date.

Fix: If rank is the same, then don't update db of that rank